### PR TITLE
Prepend /usr/local/bin/pymol to the list of locations checked for an installed pymol

### DIFF
--- a/src/mds/mds/clinit.cl
+++ b/src/mds/mds/clinit.cl
@@ -455,7 +455,8 @@
 (when (and (not (running-on-windows-p))
 	   (not (boundp '*pymol-executable-filename*)))
   (defvar *pymol-executable-filename*
-      (cond ((probe-file "/Applications/MacPyMOL.app/Contents/MacOS/PyMOL")    "/Applications/MacPyMOL.app/Contents/MacOS/PyMOL")
+      (cond ((probe-file "/usr/local/bin/pymol")                               "/usr/local/bin/pymol")
+            ((probe-file "/Applications/MacPyMOL.app/Contents/MacOS/PyMOL")    "/Applications/MacPyMOL.app/Contents/MacOS/PyMOL")
 	    ((probe-file "/Applications/MacPyMOL.app/Contents/MacOS/MacPyMOL") "/Applications/MacPyMOL.app/Contents/MacOS/MacPyMOL")
 	    (t (progn (format t "~2%    >>>>>  Warning: Pymol executable not in an expected place, either install pymol, or edit clinit.cl point to where it is already installed.~2%")
 		      "Pymol executable not in an expected place, either install pymol, or edit clinit.cl point to where it is already installed.")))))


### PR DESCRIPTION
At the very least this need to be changed (brew pymol is installed in /usr/local/bin/pymol).
