### PR TITLE
Change default location of lispmds sources to be under /usr/local/lispmds

### DIFF
--- a/src/mds/mds/clinit.cl
+++ b/src/mds/mds/clinit.cl
@@ -309,7 +309,7 @@
 (setq *unix-source-filename-root* 
   (if (sys:getenv "MDS_ROOT")
       (concatenate 'string (sys:getenv "MDS_ROOT") "/src/mds")
-    "~/mds/src/mds"))
+    "/usr/local/lispmds/src/mds"))
 
 
 ;; cmucl needs full path (it seems), leave other with ~ as that is more general for systems that are not /home/dsmith - based


### PR DESCRIPTION
This only affects those that do not have an `MDS_ROOT` variable set.

Fixes #12.
