### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,7 @@ doesn't work, ask for help.
 LispMDS can interact with [PyMOL](https://www.pymol.org/). Set that up via:
 
 ```
-$ brew tap homebrew/science
-$ brew install pymol
+$ brew install brewsci/bio/pymol
 ```
 
 ### Check that pymol works


### PR DESCRIPTION
pymol developers have updated how to install pymol with brew. (See https://pymolwiki.org/index.php/MAC_Install).

Tested on my machine running OS X 10.14, works great.